### PR TITLE
(breaking change) bump crystal support to 1.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,18 @@
 name: CI
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
+
 
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: crystallang/crystal:0.34.0-alpine
+      image: crystallang/crystal:1.6.0-alpine
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: apk add --no-cache libarchive-dev
     - name: Test

--- a/src/archive.cr
+++ b/src/archive.cr
@@ -27,7 +27,7 @@ module Archive
   class Entry
     getter filename : String
     getter size : LibC::SizeT
-    getter info : Crystal::System::FileInfo
+    getter info : File::Info
 
     property file : File?
 
@@ -75,7 +75,7 @@ module Archive
         name = String.new char_ptr
 
         stat = LibArchive.archive_entry_stat(e).value
-        info = Crystal::System::FileInfo.new stat
+        info = File::Info.new stat
         entry = Entry.new name, size, info
 
         yield entry


### PR DESCRIPTION
On upgrading to next crystal version, the following error was observed:

```
Error: instantiating 'Crystal::System::FileInfo.new(LibC::Stat)'
```

This is due to change in behaviour introduced in [Crystal 1.6.0](https://crystal-lang.org/api/1.6.0/File/Info.html), where `File::Info` became a `struct` and in [earlier versions](https://crystal-lang.org/api/1.5.0/File/Info.html). it was `abstract struct`. Additionally, in the [latest version](https://crystal-lang.org/api/1.14.0/File/Info.html) `Crystal::System::FileInfo` became a module